### PR TITLE
dev-util/rust-analyzer: Fix install

### DIFF
--- a/dev-util/rust-analyzer/rust-analyzer-99999999.ebuild
+++ b/dev-util/rust-analyzer/rust-analyzer-99999999.ebuild
@@ -195,8 +195,6 @@ IUSE=""
 DEPEND=">=dev-lang/rust-1.46.0[rls]"
 RDEPEND="${DEPEND}"
 
-CARGO_INSTALL_PATH="${S}/crates/rust-analyzer"
-
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then
 		git-r3_src_unpack
@@ -205,4 +203,8 @@ src_unpack() {
 		cargo_src_unpack
 		mv -T "${PN}-${MY_PV}" "${P}" || die
 	fi
+}
+
+src_install() {
+	cargo_src_install --path "./crates/rust-analyzer"
 }


### PR DESCRIPTION
cargo.eclass's [newest update](https://gitweb.gentoo.org/repo/gentoo.git/commit/eclass/cargo.eclass?id=be8bafc57aff94f0f708726805bccd44ddcd30a8) made changes to cargo_src_install which
replaced CARGO_INSTALL_PATH with 'cargo_src_install --path'